### PR TITLE
canonical 원문 주소로 변경, 오타 수정

### DIFF
--- a/content/Build-System/01-Overview.mdx
+++ b/content/Build-System/01-Overview.mdx
@@ -3,6 +3,7 @@ title: 'Build System Overview'
 metaTitle: 'Build System Overview'
 metaDescription: 'Documentation about the ReScript build system and its toolchain'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/build-overview'
+canonical: 'https://rescript-lang.org/docs/manual/latest/build-overview'
 ---
 
 ReScript comes with a build system, bsb, that's meant to be fast, lean and used as the authoritative build system of the community.

--- a/content/Build-System/02-Configuration.mdx
+++ b/content/Build-System/02-Configuration.mdx
@@ -3,6 +3,7 @@ title: 'Configuration'
 metaTitle: 'Build System Configuration'
 metaDescription: 'Details about the configuration of the ReScript build system (bsconfig.json)'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/build-configuration'
+canonical: 'https://rescript-lang.org/docs/manual/latest/build-configuration'
 ---
 
 `bsconfig.json` is the single, mandatory build meta file needed for bsb.

--- a/content/Build-System/03-Configuration-Schema.mdx
+++ b/content/Build-System/03-Configuration-Schema.mdx
@@ -3,4 +3,5 @@ title: 'Configuration Schema'
 metaTitle: 'Build System Configuration'
 metaDescription: 'Schema exploration widget for the ReScript configuration file'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/build-configuration-schema'
+canonical: 'https://rescript-lang.org/docs/manual/latest/build-configuration-schema'
 ---

--- a/content/Build-System/04-Interop-with-JS-Build-Systems.mdx
+++ b/content/Build-System/04-Interop-with-JS-Build-Systems.mdx
@@ -3,6 +3,7 @@ title: 'Interop with JS Build Systems'
 metaTitle: 'Interop with JS Build Systems'
 metaDescription: 'Documentation on how to interact with existing JS build systems'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/interop-with-js-build-systems'
+canonical: 'https://rescript-lang.org/docs/manual/latest/interop-with-js-build-systems'
 ---
 
 If you come from JS, chances are that you already have a build system in your existing project. Here's an overview of the role bsb would play in your build pipeline, if you want to introduce some ReScript code into the codebase.

--- a/content/Build-System/05-Performance.mdx
+++ b/content/Build-System/05-Performance.mdx
@@ -3,6 +3,7 @@ title: 'Performance'
 metaTitle: 'Build Performance'
 metaDescription: 'ReScript build performance and measuring tools'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/build-performance'
+canonical: 'https://rescript-lang.org/docs/manual/latest/build-performance'
 ---
 
 ReScript considers performance at install time, build time and run time as a serious feature. Here are some more info, and tips on keeping the build fast. **Feel free to skip this section** if you're just starting out.

--- a/content/Extra/01-Newcomer-Examples.mdx
+++ b/content/Extra/01-Newcomer-Examples.mdx
@@ -3,6 +3,7 @@ title: '초보자를 위한 예제'
 metaTitle: 'Newcomer Examples'
 metaDescription: 'Quick examples for users new to ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/newcomer-examples'
+canonical: 'https://rescript-lang.org/docs/manual/latest/newcomer-examples'
 ---
 
 이 섹션은 새로 리스크립트를 배우려는 분들을 위해 만들어졌습니다.

--- a/content/Extra/02-Project-Structure.mdx
+++ b/content/Extra/02-Project-Structure.mdx
@@ -3,6 +3,7 @@ title: 'Project Structure'
 metaTitle: 'Project Structure'
 metaDescription: 'Notes on project structure and other rough ReScript guidelines'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/project-structure'
+canonical: 'https://rescript-lang.org/docs/manual/latest/project-structure'
 ---
 
 These are the existing, non-codified community practices that are currently propagated through informal agreement. We might remove some of them at one point, and enforce some others. Right now, they're just recommendations for ease of newcomers.

--- a/content/Extra/03-FAQ.mdx
+++ b/content/Extra/03-FAQ.mdx
@@ -2,7 +2,8 @@
 title: '자주 묻는 질문'
 metaTitle: 'FAQ'
 metaDescription: 'ReScript와 생테계에 관해 자주 묻는 질문'
-canonical: '/faq'
+sourceUrl: 'https://rescript-lang.org/docs/manual/latest/faq'
+canonical: 'https://rescript-lang.org/docs/manual/latest/faq'
 ---
 
 **이 프로젝트의 목표는 무엇인가요?**

--- a/content/Guides/01-Converting-from-JS.mdx
+++ b/content/Guides/01-Converting-from-JS.mdx
@@ -3,6 +3,7 @@ title: '자바스크립트 파일을 변환하기'
 metaTitle: 'Converting from JS'
 metaDescription: 'How to convert to ReScript with an existing JS codebase'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/converting-from-js'
+canonical: 'https://rescript-lang.org/docs/manual/latest/converting-from-js'
 ---
 
 리스크립트는 프로젝트를 변환하는 고유한 방법을 제공합니다.

--- a/content/Guides/02-Libraries.mdx
+++ b/content/Guides/02-Libraries.mdx
@@ -3,6 +3,7 @@ title: 'Libraries'
 metaTitle: 'Libraries'
 metaDescription: 'ReScript libraries'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/libraries'
+canonical: 'https://rescript-lang.org/docs/manual/latest/libraries'
 ---
 
 ReScript libraries are just like JavaScript libraries: hosted on [NPM](http://npmjs.com).

--- a/content/JavaScript-Interop/01-Embed-Raw-JavaScript.mdx
+++ b/content/JavaScript-Interop/01-Embed-Raw-JavaScript.mdx
@@ -3,6 +3,7 @@ title: 'Embed Raw JavaScript'
 metaTitle: 'Embed Raw JavaScript'
 metaDescription: 'Utility syntax to for raw JS usage in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/embed-raw-javascript'
+canonical: 'https://rescript-lang.org/docs/manual/latest/embed-raw-javascript'
 ---
 
 ## Paste Raw JS Code

--- a/content/JavaScript-Interop/02-Shared-Data-Types.mdx
+++ b/content/JavaScript-Interop/02-Shared-Data-Types.mdx
@@ -3,6 +3,7 @@ title: 'Shared Data Types'
 metaTitle: 'Shared Data Types'
 metaDescription: 'Data types that share runtime presentation between JS and ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/shared-data-types'
+canonical: 'https://rescript-lang.org/docs/manual/latest/embed-raw-javascript'
 ---
 
 ReScript's built-in values of type `string`, `float`, `array` and a few others have a rather interesting property: they compile to the exact same value in JavaScript!

--- a/content/JavaScript-Interop/03-External-Bind-to-Any-JS-Library.mdx
+++ b/content/JavaScript-Interop/03-External-Bind-to-Any-JS-Library.mdx
@@ -3,6 +3,7 @@ title: 'External (Bind to Any JS Library)'
 metaTitle: 'External (Bind to Any JS Library)'
 metaDescription: 'The external keyword'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/external'
+canonical: 'https://rescript-lang.org/docs/manual/latest/external'
 ---
 
 `external` is the primary ReScript features for bringing in and using JavaScript values.

--- a/content/JavaScript-Interop/04-Bind-to-JS-Object.mdx
+++ b/content/JavaScript-Interop/04-Bind-to-JS-Object.mdx
@@ -3,6 +3,7 @@ title: '자바스크립트 객체에 바인딩하기.'
 metaTitle: '자바스크립트 객체에 바인딩하기'
 metaDescription: '리스크립트와 자바스크립트 객체간 연동하기'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/bind-to-js-object'
+canonical: 'https://rescript-lang.org/docs/manual/latest/bind-to-js-object'
 ---
 
 <!-- JavaScript objects are a combination of several use-cases: -->

--- a/content/JavaScript-Interop/05-Bind-to-JS-Function.mdx
+++ b/content/JavaScript-Interop/05-Bind-to-JS-Function.mdx
@@ -3,6 +3,7 @@ title: 'Bind to JS Function'
 metaTitle: 'Bind to JS Function'
 metaDescription: 'JS interop with functions in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/bind-to-js-function'
+canonical: 'https://rescript-lang.org/docs/manual/latest/bind-to-js-function'
 ---
 
 Binding a JS function is like binding any other value:

--- a/content/JavaScript-Interop/06-Import-from-Export-to-JS.mdx
+++ b/content/JavaScript-Interop/06-Import-from-Export-to-JS.mdx
@@ -3,6 +3,7 @@ title: 'Import from / Export to JS'
 metaTitle: 'Import from / Export to JS'
 metaDescription: 'Importing / exporting JS module content in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/import-from-export-to-js'
+canonical: 'https://rescript-lang.org/docs/manual/latest/import-from-export-to-js'
 ---
 
 You've seen how ReScript's idiomatic [Import & Export](import-export.md) works. This section describes how we work with importing stuff from JavaScript and exporting stuff for JavaScript consumption.

--- a/content/JavaScript-Interop/07-Bind-to-Global-JS-Values.mdx
+++ b/content/JavaScript-Interop/07-Bind-to-Global-JS-Values.mdx
@@ -3,6 +3,7 @@ title: 'Bind to Global JS Values'
 metaTitle: 'Bind to Global JS Values'
 metaDescription: 'JS interop with global JS values in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/bind-to-global-js-values'
+canonical: 'https://rescript-lang.org/docs/manual/latest/bind-to-global-js-values'
 ---
 
 **First**, make sure the value you'd like to model doesn't already exist in our [provided API](api/js).

--- a/content/JavaScript-Interop/08-JSON.mdx
+++ b/content/JavaScript-Interop/08-JSON.mdx
@@ -3,6 +3,7 @@ title: 'JSON'
 metaTitle: 'JSON'
 metaDescription: 'Interacting with JSON in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/json'
+canonical: 'https://rescript-lang.org/docs/manual/latest/json'
 ---
 
 ## Parse

--- a/content/JavaScript-Interop/09-Inlining-Constants.mdx
+++ b/content/JavaScript-Interop/09-Inlining-Constants.mdx
@@ -3,6 +3,7 @@ title: 'Inlining Constants'
 metaTitle: 'Inlining Constants'
 metaDescription: 'Inlining constants'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/inlining-constants'
+canonical: 'https://rescript-lang.org/docs/manual/latest/inlining-constants'
 ---
 
 Sometime, in the JavaScript output, you might want a certain value to be forcefully inlined. For example:

--- a/content/JavaScript-Interop/10-Use-Illegal-Identifier-Names.mdx
+++ b/content/JavaScript-Interop/10-Use-Illegal-Identifier-Names.mdx
@@ -3,15 +3,16 @@ title: 'Use Illegal Identifier Names'
 metaTitle: 'Use Illegal Identifier Names'
 metaDescription: 'Handling (JS) naming collisions in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/use-illegal-identifier-names'
+canonical: 'https://rescript-lang.org/docs/manual/latest/use-illegal-identifier-names'
 ---
 
-Sometime, for e.g. a let binding or a record field, you might want to use:
+때때로 let 바인딩 또는 레코드 필드에 이런 것을 사용하고 싶을 수 있습니다.
 
-- A capitalized name.
-- A name that contains illegal characters (e.g. emojis, hyphen, space).
-- A name that's one of ReScript's reserved keywords.
+- 대문자 이름
+- 들어가서는 안 될 문자열을 이름에 포함시킬 경우
+- 리스크립트 예약어일 경우
 
-We provide an escape hatch syntax for these cases:
+우리는 이스케이프 해치를 사용해서 다음 구문을 제공합니다.
 
 ```reason
 let \"my-🍎" = 10
@@ -45,4 +46,4 @@ function calculate(Props) {
 }
 ```
 
-결과물을 보세요. 자바스크립트 인터롭을 할 경우 **꼭 필요할 경우만 사용하세요**. This is a last-resort feature. If you abuse this, many of the compiler guarantees will go away.
+결과물을 보세요. 자바스크립트 인터롭을 할 경우 **꼭 필요할 경우만 사용하세요**. 이건 최후의 수단입니다. 이것을 남용하면 많은 컴파일러 보증이 사라집니다.

--- a/content/JavaScript-Interop/12-Browser-Support-Polyfills.mdx
+++ b/content/JavaScript-Interop/12-Browser-Support-Polyfills.mdx
@@ -3,6 +3,7 @@ title: 'Browser Support & Polyfills'
 metaTitle: 'Browser Support & Polyfills'
 metaDescription: 'Note on browser support in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/browser-support-polyfills'
+canonical: 'https://rescript-lang.org/docs/manual/latest/browser-support-polyfills'
 ---
 
 ReScript compiles to JavaScript **ES5**, with the exception of optionally allowing to compile to ES6's module import & export.

--- a/content/JavaScript-Interop/13-Interop-Cheatsheet.mdx
+++ b/content/JavaScript-Interop/13-Interop-Cheatsheet.mdx
@@ -3,6 +3,7 @@ title: 'Interop Cheatsheet'
 metaTitle: 'Interop Cheatsheet'
 metaDescription: 'Cheatsheet for various interop scenarios in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/interop-cheatsheet'
+canonical: 'https://rescript-lang.org/docs/manual/latest/interop-cheatsheet'
 ---
 
 <!-- TODO: this should be a glossary instead -->

--- a/content/Language-Features/01-Overview.mdx
+++ b/content/Language-Features/01-Overview.mdx
@@ -3,6 +3,7 @@ title: '개요'
 metaTitle: '언어 특징 개요'
 metaDescription: '리스트립트의 문법 개요 빠르게 훑어보기'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/overview'
+canonical: 'https://rescript-lang.org/docs/manual/latest/overview'
 ---
 
 ## 자바스트립트와 비교

--- a/content/Language-Features/02-Let-Binding.mdx
+++ b/content/Language-Features/02-Let-Binding.mdx
@@ -3,6 +3,7 @@ title: 'Let Binding'
 metaTitle: 'Let Binding'
 metaDescription: 'ReScript에서 값을 바인딩하는 Let 바인딩 문법'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/let-binding'
+canonical: 'https://rescript-lang.org/docs/manual/latest/let-binding'
 ---
 
 다른 언어에서 "let binding"은 "변수 선언" 이라 할 수 있습니다. `let`은 값과 변수 이름을 _묶는(bind)_ 것입니다. "let binding"을 하면 _이후_ 코드에서 바인딩 된 변수를 참조할 수 있습니다.

--- a/content/Language-Features/03-Type.mdx
+++ b/content/Language-Features/03-Type.mdx
@@ -3,6 +3,7 @@ title: '타입'
 metaTitle: '타입(Type), 리스크립트에서 타입의 뜻'
 metaDescription: '리스크립트에서 타입과 타입 정의'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/type'
+canonical: 'https://rescript-lang.org/docs/manual/latest/type'
 ---
 
 타입(Type)은 리스크립트의 꽃이라 할 수 있습니다! 타입은

--- a/content/Language-Features/04-Primitive-Types.mdx
+++ b/content/Language-Features/04-Primitive-Types.mdx
@@ -3,6 +3,7 @@ title: '원시 타입'
 metaTitle: '원시 타입(Primitive Types)'
 metaDescription: 'ReScript의 원시 데이터 타입들'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/primitive-types'
+canonical: 'https://rescript-lang.org/docs/manual/latest/primitive-types'
 ---
 
 리스크립트는 `string`, `int`, `float` 등 친숙한 원시타입이 있습니다.

--- a/content/Language-Features/05-Tuple.mdx
+++ b/content/Language-Features/05-Tuple.mdx
@@ -3,6 +3,7 @@ title: '튜플'
 metaTitle: '튜플(Tuple)'
 metaDescription: '튜플 자료구조'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/tuple'
+canonical: 'https://rescript-lang.org/docs/manual/latest/tuple'
 ---
 
 튜플(Tuple)은 자바스크립트에 존재하지 않는 리스크립트만의 자료구조입니다.

--- a/content/Language-Features/06-Record.mdx
+++ b/content/Language-Features/06-Record.mdx
@@ -3,6 +3,7 @@ title: '레코드'
 metaTitle: '레코드(Record)'
 metaDescription: '레코드 자료구조'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/record'
+canonical: 'https://rescript-lang.org/docs/manual/latest/record'
 ---
 
 레코드(Record)는 자바스크립트 객체(Object)와 유사합니다. 다만,

--- a/content/Language-Features/07-Object.mdx
+++ b/content/Language-Features/07-Object.mdx
@@ -3,6 +3,7 @@ title: '객체'
 metaTitle: '객체(Object)'
 metaDescription: '리스크립트에서 자바스크립트 객체 인터롭'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/object'
+canonical: 'https://rescript-lang.org/docs/manual/latest/object'
 ---
 
 리스크립트의 객체는 [레코드](06-Record)와 비슷합니다. 하지만,

--- a/content/Language-Features/08-Variant.mdx
+++ b/content/Language-Features/08-Variant.mdx
@@ -3,6 +3,7 @@ title: '배리언트'
 metaTitle: '배리언트(Variant)'
 metaDescription: '리스크립트의 배리언트 자료구조'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/variant'
+canonical: 'https://rescript-lang.org/docs/manual/latest/variant'
 ---
 
 지금까지 리스크립트 자료구조 대부분은 익숙해 보일것입니다.

--- a/content/Language-Features/09-Polymorphic-Variant.mdx
+++ b/content/Language-Features/09-Polymorphic-Variant.mdx
@@ -3,6 +3,7 @@ title: 'Polymorphic Variant'
 metaTitle: 'Polymorphic Variant'
 metaDescription: 'The Polymorphic Variant data structure in ReScript'
 sourceUrl: https://rescript-lang.org/docs/manual/latest/polymorphic-variant
+canonical: https://rescript-lang.org/docs/manual/latest/polymorphic-variant
 ---
 
 Now that we know what [variant types](./variant) are, let's dive into a more specific version, so called polymorphic variants (or poly variants).

--- a/content/Language-Features/10-Null-Undefined-and-Option.mdx
+++ b/content/Language-Features/10-Null-Undefined-and-Option.mdx
@@ -3,6 +3,7 @@ title: 'Null, Undefined 그리고 Option'
 metaTitle: 'Null, Undefined 그리고 Option'
 metaDescription: '리스크립트에서 nullable optional 값과 JS 인터롭(상호운용)'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/null-undefined-option'
+canonical: 'https://rescript-lang.org/docs/manual/latest/null-undefined-option'
 ---
 
 리스크립트 자체는 `null` 또는 `undefined`에 대한 개념이 없습니다. 이건 버그의 전체 범주를 제거하는 정말 _훌륭한_ 일입니다. 더 이상 `undefined is not a function`, 그리고 `cannot access someAttribute of undefined` 오류는 없습니다!

--- a/content/Language-Features/11-Array-List.mdx
+++ b/content/Language-Features/11-Array-List.mdx
@@ -3,6 +3,7 @@ title: '배열과 리스트'
 metaTitle: '배열과 리스트(Array & List)'
 metaDescription: '배열과 리스트 (Array & List) 데이터 구조'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/array-and-list'
+canonical: 'https://rescript-lang.org/docs/manual/latest/array-and-list'
 ---
 
 ## 배열

--- a/content/Language-Features/12-Function.mdx
+++ b/content/Language-Features/12-Function.mdx
@@ -3,6 +3,7 @@ title: '함수'
 metaTitle: '함수 (Function)'
 metaDescription: '리스크립트에서의 함수 구문'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/function'
+canonical: 'https://rescript-lang.org/docs/manual/latest/function'
 ---
 
 _페이지 끝에 전체 함수 문법 치트 시트가 있습니다_.

--- a/content/Language-Features/13-Control-Flow.mdx
+++ b/content/Language-Features/13-Control-Flow.mdx
@@ -3,6 +3,7 @@ title: '제어 흐름'
 metaTitle: '제어 흐름(Control Flow)'
 metaDescription: 'If, else, 삼항 표현(ternary), for 및 while과 같은 구조'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/control-flow'
+canonical: 'https://rescript-lang.org/docs/manual/latest/control-flow'
 ---
 
 리스크립트에서는 `if`, `else`, 삼항 표현(ternary expression), `for` 및 `while`을 지원합니다.

--- a/content/Language-Features/14-Pipe.mdx
+++ b/content/Language-Features/14-Pipe.mdx
@@ -3,6 +3,7 @@ title: '파이프'
 metaTitle: '파이프(Pipe)'
 metaDescription: 'The Pipe operator (->)'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/pipe'
+canonical: 'https://rescript-lang.org/docs/manual/latest/pipe'
 ---
 
 리스크립트는 파이프 연산자(`->`)를 지원합니다. 파이프를 이용하면 `a(b)`를 `b->a`와 같이 작성할 수 있습니다. 파이프는 단순히 방향을 바꿔주는 문법일 뿐이어서 사용할 때 별도의 성능 저하는 없습니다.

--- a/content/Language-Features/15-Pattern-Matching-Destructuring.mdx
+++ b/content/Language-Features/15-Pattern-Matching-Destructuring.mdx
@@ -3,6 +3,7 @@ title: '패턴 매칭 / 구조분해'
 metaTitle: '패턴 매칭 / 구조분해(Pattern Matching / Destructuring)'
 metaDescription: 'Pattern matching and destructuring complex data structures in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/pattern-matching-destructuring'
+canonical: 'https://rescript-lang.org/docs/manual/latest/pattern-matching-destructuring'
 ---
 
 리스크립트의 **최고** 기능 중 하나는 패턴 매칭입니다. 패턴 매칭은 세가지 뛰어난 기능을 하나로 결합합니다.

--- a/content/Language-Features/16-Mutation.mdx
+++ b/content/Language-Features/16-Mutation.mdx
@@ -3,6 +3,7 @@ title: '가변'
 metaTitle: '가변 (Mutation)'
 metaDescription: 'Imperative and mutative programming capabilities in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/mutation'
+canonical: 'https://rescript-lang.org/docs/manual/latest/mutation'
 ---
 
 리스크립트는 전통적인 명령형 및 가변 프로그래밍 기능을 갖추고 있습니다.

--- a/content/Language-Features/17-JSX.mdx
+++ b/content/Language-Features/17-JSX.mdx
@@ -3,6 +3,7 @@ title: 'JSX'
 metaTitle: 'JSX'
 metaDescription: '리즌리액트와 리스크립트의 JSX 문법'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/jsx'
+canonical: 'https://rescript-lang.org/docs/manual/latest/jsx'
 ---
 
 리스크립트로 HTML 구문을 작성할 것 같으신가요? 아니라면 이 섹션은 그냥 넘어가셔도 됩니다.

--- a/content/Language-Features/18-Exception.mdx
+++ b/content/Language-Features/18-Exception.mdx
@@ -3,6 +3,7 @@ title: '예외'
 metaTitle: '예외 (Exception)'
 metaDescription: '리스크립트에서 예외와 예외 처리'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/exception'
+canonical: 'https://rescript-lang.org/docs/manual/latest/exception'
 ---
 
 예외는 **예외 케이스**일 때 던지는 특별한 종류의 배리언트입니다. (남용하지 마세요!)

--- a/content/Language-Features/19-Lazy-Value.mdx
+++ b/content/Language-Features/19-Lazy-Value.mdx
@@ -3,6 +3,7 @@ title: 'Lazy Value'
 metaTitle: 'Lazy Value'
 metaDescription: 'Data type for deferred computation in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/lazy-values'
+canonical: 'https://rescript-lang.org/docs/manual/latest/lazy-values'
 ---
 
 지연된 값은 나중에 계산하는 것을 표현합니다. 이는 자동으로 첫번째 실행 결과를 기억해줍니다. 그리고 어떤 반복된 실행의 결과를 기억한 값을 리턴합니다.

--- a/content/Language-Features/20-Async-Promise.mdx
+++ b/content/Language-Features/20-Async-Promise.mdx
@@ -3,6 +3,7 @@ title: 'Async & Promise'
 metaTitle: 'Async & Promise'
 metaDescription: 'JS Promise handling in ReScript'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/promise'
+canonical: 'https://rescript-lang.org/docs/manual/latest/promise'
 ---
 
 비동기 프로그래밍에서 리스크립트의 주요 메커니즘은 자바스크립트와 같습니다(callbacks and promises). 그 이유는 자바스크립트로 깔끔하게 컴파일 하고 싶기도 하고 실행시간에 무거워지고 느려지는 것을 피하고 싶기 때문입니다.

--- a/content/Language-Features/21-Module.mdx
+++ b/content/Language-Features/21-Module.mdx
@@ -3,6 +3,7 @@ title: '모듈'
 metaTitle: 'Module'
 metaDescription: 'ReScript에서 코드들을 묶는 역할을 합니다.'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/module'
+canonical: 'https://rescript-lang.org/docs/manual/latest/module'
 ---
 
 ## 개요

--- a/content/Language-Features/22-Import-Export.mdx
+++ b/content/Language-Features/22-Import-Export.mdx
@@ -3,6 +3,7 @@ title: 'Import & Export'
 metaTitle: 'Import & Export'
 metaDescription: 'Importing / exporting in ReScript modules'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/import-export'
+canonical: 'https://rescript-lang.org/docs/manual/latest/import-export'
 ---
 
 ## 모듈/파일 가져오기 (Import)

--- a/content/Language-Features/23-Attribute-Decorator.mdx
+++ b/content/Language-Features/23-Attribute-Decorator.mdx
@@ -3,6 +3,7 @@ title: '속성 (데코레이터)'
 metaTitle: '속성 (데코레이터)'
 metaDescription: '리스크립트의 어노테이션(속성 또는 데코레이터) 선언'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/attribute'
+canonical: 'https://rescript-lang.org/docs/manual/latest/attribute'
 ---
 
 다른 여러 언어들처럼 리스크립트는 코드 조각을 속성으로 선언해 추가적인 기능을 얻는 것을 허용합니다. 여기 예시가 있습니다.

--- a/content/Language-Features/24-Unboxed.mdx
+++ b/content/Language-Features/24-Unboxed.mdx
@@ -3,6 +3,7 @@ title: '언박싱'
 metaTitle: '언박싱(Unboxed)'
 metaDescription: '래퍼를 언박싱합니다.'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/unboxed'
+canonical: 'https://rescript-lang.org/docs/manual/latest/unboxed'
 ---
 
 <!--Consider a ReScript variant with a single payload, and a record with a single field: -->

--- a/content/Language-Features/25-Reserved-Keyword.mdx
+++ b/content/Language-Features/25-Reserved-Keyword.mdx
@@ -3,6 +3,7 @@ title: '예약된 키워드'
 metaTitle: 'Reserved Keyword'
 metaDescription: '리스크립트에서 예약된 모든 키워드'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/reserved-keywords'
+canonical: 'https://rescript-lang.org/docs/manual/latest/reserved-keywords'
 ---
 
 > **참고**: 몇가지 단어는 하위 호환성을 위해 예약되었습니다.

--- a/content/Overview/01-Introduction.mdx
+++ b/content/Overview/01-Introduction.mdx
@@ -3,7 +3,7 @@ title: '소개'
 metaTitle: '소개 (Introduction)'
 metaDescription: 'ReScript in Korean'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/introduction'
-canonical: '/docs/manual/latest/introduction'
+canonical: 'https://rescript-lang.org/docs/manual/latest/introduction'
 ---
 
 # ReScript
@@ -57,7 +57,7 @@ canonical: '/docs/manual/latest/introduction'
 
 리스크립트 빌드 시간은 자바스크립트 생태계의 다른 정적 타이핑 환경보다 **1 ~ 2배**빠릅니다. 워치 모드중일 때 파일이 변경되면 다음 빌드는 터미널 탭을 전환하기도 전에 완료됩니다(2자리 밀리초). 이렇게 빠르게 빌드가 완료되고 반영되는 환경은 개발자가 작업에 더 집중할 수 있게 해줍니다.
 
-### 가독성을 고려한 결과물 & 훌륭햔 인터롭(상호운용)
+### 가독성을 고려한 결과물 & 훌륭한 인터롭(상호운용)
 
 다른 언어에서 컴파일 후 생성된 읽기 힘든 자바스크립트 코드는 다음과 같은 곤란함이 있습니다.
 

--- a/content/Overview/02-Installation.mdx
+++ b/content/Overview/02-Installation.mdx
@@ -3,6 +3,7 @@ title: '설치'
 metaTitle: 'Installation(설치)'
 metaDescription: 'ReScript 설치와 셋업 방법'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/installation'
+canonical: 'https://rescript-lang.org/docs/manual/latest/installation'
 ---
 
 준비사항: NodeJS 환경, 그리고 NPM 또는 Yarn

--- a/content/Overview/03-EditorPlugins.mdx
+++ b/content/Overview/03-EditorPlugins.mdx
@@ -3,6 +3,7 @@ title: '편집기 플러그인'
 metaTitle: '편집기 플러그인 (Editor Plugins)'
 metaDescription: 'List of ReScript editor plugins'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/editor-plugins'
+canonical: 'https://rescript-lang.org/docs/manual/latest/editor-plugins'
 ---
 
 - [Sublime Text](https://github.com/reasonml-editor/sublime-reason) (추천)

--- a/content/Overview/04-Migrate-to-ReScript-Syntax.mdx
+++ b/content/Overview/04-Migrate-to-ReScript-Syntax.mdx
@@ -3,6 +3,7 @@ title: '리스크립트 문법으로 변경하기'
 metaTitle: '리스크립트 문법으로 변경하기(Migrate to ReScript Syntax)'
 metaDescription: '리즌에서 리스크립트로 업그레이드 하는 방법을 설명합니다.'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/migrate-from-bucklescript-reason'
+canonical: 'https://rescript-lang.org/docs/manual/latest/migrate-from-bucklescript-reason'
 ---
 
 리스크립트는 버클스크립트 `v8.2.0`, 리즌 `v3.6` 이후 정리 및 리브랜딩 됐습니다. 만약 이전 버전을 사용했었다면 다음 내용을 참고하세요.

--- a/content/Overview/05-Try.mdx
+++ b/content/Overview/05-Try.mdx
@@ -3,6 +3,7 @@ title: 'CLI로 직접 해보기'
 metaTitle: 'CLI로 직접 해보기'
 metaDescription: 'CLI를 통해 ReScript를 사용해봅니다'
 sourceUrl: 'https://rescript-lang.org/docs/manual/latest/try'
+canonical: 'https://rescript-lang.org/docs/manual/latest/try'
 ---
 
 <!-- TODO: rename to Command Line, document options like -format -->

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -73,11 +73,12 @@ export default class MDXRuntimeTest extends Component {
     // rescript source path
     const sourceUrl = mdx.frontmatter?.sourceUrl;
 
-    let canonicalUrl = config.gatsby.siteUrl;
+    const canonical = mdx.frontmatter?.canonical;
+    
 
-    canonicalUrl =
-      config.gatsby.pathPrefix !== '/' ? canonicalUrl + config.gatsby.pathPrefix : canonicalUrl;
-    canonicalUrl = canonicalUrl + mdx.fields.slug;
+    // canonicalUrl =
+    //   config.gatsby.pathPrefix !== '/' ? canonicalUrl + config.gatsby.pathPrefix : canonicalUrl;
+    // canonicalUrl = canonicalUrl + mdx.fields.slug;
 
     return (
       <Layout {...this.props}>
@@ -91,7 +92,7 @@ export default class MDXRuntimeTest extends Component {
           {metaDescription ? (
             <meta property="twitter:description" content={metaDescription} />
           ) : null}
-          <link rel="canonical" href={canonicalUrl} />
+          {canonical && <link rel="canonical" href={canonical} />}
         </Helmet>
         <div className={'titleWrapper'}>
           <StyledHeading>{mdx.fields.title}</StyledHeading>
@@ -145,6 +146,7 @@ export const pageQuery = graphql`
         metaTitle
         metaDescription
         sourceUrl
+        canonical
       }
     }
     allMdx {


### PR DESCRIPTION
- canonical 원문 주소로 변경 `https://rescript-lang.org/community/translations` 참고
- 오타 수정
- 