### PR TITLE
[Fix] Typo link in Object section

### DIFF
--- a/content/Language-Features/07-Object.mdx
+++ b/content/Language-Features/07-Object.mdx
@@ -11,7 +11,7 @@ canonical: 'https://rescript-lang.org/docs/manual/latest/object'
 - 타입 선언이 필요없습니다.
 - [레코드와 다르게](06-Record) 구조적(structural)이고 더 폴리몰픽합니다.
 - 객체가 JS로부터 전달된 것이 아니면 변경할 수 없습니다.
-- [패턴매칭](15-Parttern-Matching-Desctuctring)을 지원하지 않습니다.
+- [패턴매칭](15-Pattern-Matching-Destructuring)을 지원하지 않습니다.
 
 물론 리스크립트 레코드가 자바스크립트 객체로 깔끔하게 컴파일되긴 하지만, 자바스크립트 객체를 흉내내거나 바인딩할 때에는 리스크립트의 객체가 더 나은 선택일 수 있습니다.
 


### PR DESCRIPTION
번역본 잘 보고있습니다! 감사합니다. 🙏

- Fix typo link `15-Parttern-Matching-Desctuctring` to `15-Pattern-Matching-Destructuring`
- 깨진 링크가 있어서 수정했습니다
