### PR TITLE
[Fix] Type link in Configuration

### DIFF
--- a/content/Build-System/02-Configuration.mdx
+++ b/content/Build-System/02-Configuration.mdx
@@ -77,13 +77,13 @@ canonical: 'https://rescript-lang.org/docs/manual/latest/build-configuration'
 
 **8.4 이후**: 고정 의존성 목록입니다. 고정 의존성은 `rescript` 로 최상위 패키지(예: 메인 앱)을 빌드할 때마다 항상 다시 빌드됩니다.
 
-고정 의존성은 여러 독립된 리스크립트 패키지와 함께 사용하는데 유용합니다. 자세한 사용법은 [고정 의존성](./build-pinned-dependencies) 페이지에서 확인할 수 있습니다.
+고정 의존성은 여러 독립된 리스크립트 패키지와 함께 사용하는데 유용합니다. 자세한 사용법은 [고정 의존성](/Build-System/05-Build-Pinned-Dependencies) 페이지에서 확인할 수 있습니다.
 
 ## external-stdlib
 
 **9.0 이후**: 이 설정은 (로컬 빌드된 stdlib 대신) 외부에서 빌드된 stdlib 패키지에 따라 허용됩니다. 리스크립트 툴체인에 대한 의존성 없이 자바스크립트 또는 타입스크립트에서만 사용하는 패키지를 만드는데 유용합니다.
 
-자세한 내용은 [external stdlib](./build-external-stdlib) 페이지에서 확인하세요.
+자세한 내용은 [external stdlib](/Build-System/04-External-Stdlib) 페이지에서 확인하세요.
 
 ## reason, refmt (오래됨)
 
@@ -150,7 +150,7 @@ CommonJS(기본값) 또는 ES6 모듈로 출력합니다. 예:
 - 여기서 자바스크립트 파일을 사용하고 있다는 것이 즉시 분명해집니다.
 - 같은 디렉터리에 `theFile.js` 가 있어서 발생하는 충돌을 방지합니다.
 - 리스크립트 파일에 빌드 시스템 로더를 사용하지 않아도 됩니다. in-source 빌드는 리스크립트 프로젝트를 순수 자바스크립트 코드베이스에 통합하는 것을 의미합니다. **기본적으로 빌드 파이프라인의 어떤 것도 건드지 않습니다.**
-- [genType](/docs/gentype/latest/introduction)은 컴파일된 자바스크립트 아티팩트에 `bs.js`가 필요합니다. `genType` 을 사용하는 경우에 현재는 `bs.js` 를 사용해야합니다.
+- [genType](https://rescript-lang.org/docs/gentype/latest/introduction)은 컴파일된 자바스크립트 아티팩트에 `bs.js`가 필요합니다. `genType` 을 사용하는 경우에 현재는 `bs.js` 를 사용해야합니다.
 
 ## warnings
 


### PR DESCRIPTION

안녕하세요.
**빌드 시스템**의 **설정** [페이지](https://green-labs.github.io/rescript-in-korean/Build-System/02-Configuration)에서 잘못된 링크 3건을 발견하여 PR을 올립니다.

## 내용
- **고정 의존성**의 링크 주소를 올바르게 고쳤습니다.
- **external stdlib**의 링크 주소를 올바르게 고쳤습니다.
- **genType**의 링크 주소가 잘못되었지만 한글 페이지가 존재하지 않아 원본(영문) 주소로 고쳤습니다.

## 참조
- [번역본](https://green-labs.github.io/rescript-in-korean/Build-System/02-Configuration)
- [원본](https://rescript-lang.org/docs/manual/latest/build-configuration)

감사합니다. 🙏
