### PR TITLE
[Fix] Typo in Pattern Matching Destructuring

### DIFF
--- a/content/Language-Features/15-Pattern-Matching-Destructuring.mdx
+++ b/content/Language-Features/15-Pattern-Matching-Destructuring.mdx
@@ -405,7 +405,7 @@ let rec printStudents = (students) => {
     printStudents(otherStudents)
   }
 }
-0printStudents(list{"Jane", "Harvey", "Patrick"})
+printStudents(list{"Jane", "Harvey", "Patrick"})
 ```
 
 ### 작은 함정


### PR DESCRIPTION
안녕하세요.
**패턴 매칭 / 구조분해**의 **리스트 매칭** [페이지](https://green-labs.github.io/rescript-in-korean/Language-Features/15-Pattern-Matching-Destructuring)에서 코드의 오타를 발견하여 PR을 올립니다.

## 내용
- **리스트 매칭**의 예시 코드의 오타를 올바르게 고쳤습니다.

## 참조
- [번역본](https://green-labs.github.io/rescript-in-korean/Language-Features/15-Pattern-Matching-Destructuring)
- [원본](https://rescript-lang.org/docs/manual/latest/pattern-matching-destructuring)

감사합니다. 🙏
