### PR TITLE
번역에서 parameter, argument를 구분합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - 여러분(o)
 - 영어는 그대로 적기보다 음차를 적극적으로 활용합니다.
   - 예) JavaScript(x), 자바스크립트(o)
-- argument, parameter는 인자로 번역합니다.
+- parameter는 매개변수로, argument는 인자로 번역합니다.
   - 인수(x)
   - labeled argument 이름있는 인자
 

--- a/content/Language-Features/03-Type.mdx
+++ b/content/Language-Features/03-Type.mdx
@@ -82,11 +82,11 @@ let x: scoreType = 10
 var x = 10;
 ```
 
-## 타입 인자(A.k.a Generic)
+## 타입 매개변수(A.k.a Generic)
 
-타입들은 인자를 받을 수 있습니다. 다른 언어에서는 Generics라고 하죠. 매개변수들의 이름은 **꼭** `'`으로 시작해야 합니다.
+타입들은 매개변수를 받을 수 있습니다. 다른 언어에서는 Generics라고 하죠. 매개변수들의 이름은 **꼭** `'`으로 시작해야 합니다.
 
-중복을 제거하기 위해 인자화 한 타입을 사용한 예제입니다.
+중복을 제거하기 위해 매개변수화 한 타입을 사용한 예제입니다.
 
 사용 전:
 
@@ -130,7 +130,7 @@ var buddy = [10, 20, 20];
 
 타입 시스템은 이것이 `(int, int, int)`라고 추론합니다. 다른 어떤 것도 쓰여질 필요가 없습니다.
 
-타입 인자는 여러 위치에 나타납니다. 리스크립트의 `array<'a>` 타입은 타입 인자가 필요한 유형입니다.
+타입 인자는 여러 위치에 나타납니다. 리스크립트의 `array<'a>` 타입은 타입 매개변수는 필요한 유형입니다.
 
 ```reason
 /* inferred as `array<string>` */
@@ -142,7 +142,7 @@ let greetings = ["hello", "world", "how are you"]
 var greetings = ['hello', 'world', 'how are you'];
 ```
 
-만약 타입 인자를 허용하지 않는다면 표준 라이브러리는 `arrayOfString`,`arrayOfInt`,`arrayOfTuplesOfInt` 등의 타입을 정의해야합니다. 아주 지루한 일이죠.
+만약 타입 매개변수를 허용하지 않는다면 표준 라이브러리는 `arrayOfString`,`arrayOfInt`,`arrayOfTuplesOfInt` 등의 타입을 정의해야합니다. 아주 지루한 일이죠.
 
 타입은 많은 인자를 받을 수 있고 구성할 수 있습니다.
 

--- a/content/Language-Features/06-Record.mdx
+++ b/content/Language-Features/06-Record.mdx
@@ -98,7 +98,7 @@ type monster = {age: int, hasTentacles: bool}
 let getAge = (entity) => entity.age
 ```
 
-`getAge`는 인자 `entity`가 `age` 필드와 가장 가까운 레코드 타입인 `monster` 타입이어야한다고 추론할 것입니다. 그래서 다음 코드의 마지막 줄이 실패합니다.
+`getAge`는 매개변수 `entity`가 `age` 필드와 가장 가까운 레코드 타입인 `monster` 타입이어야한다고 추론할 것입니다. 그래서 다음 코드의 마지막 줄이 실패합니다.
 
 ```reason
 let kraken = {age: 9999, hasTentacles: true}


### PR DESCRIPTION
# 배경
- parameter와 argument는 뜻하는 바가 다른 단어로 알고 있습니다. ([link](https://developer.mozilla.org/en-US/docs/Glossary/Parameter#:~:text=Note%20the%20difference%20between%20parameters%20and%20arguments%3A))
- 원문에서 parameter, argument 를 각 의미에 맞게 사용하고 있는 것으로 보입니다.

# 작업
- 원문에서 parameter로 작성된 문장은 매개변수로, argument는 인자로 변경합니다.

# 추후 작업 방향
- 위 작업 배경에 대해 동의가 된다면, 아래 작업을 순차적으로 진행해볼 예정입니다.
  - 기존에 '인자'로 번역된 부분들을 찾아서 추가 번역을 진행한 이후, PR 내부에 후속 커밋을 올릴 예정입니다.
    - 추가 커밋 이후에는, 기존에 리뷰해주신 분들에게 다시 PR 리뷰 요청을 드릴 예정입니다.
- parameter와 argument 는 모두 인자로 번역해도 괜찮겠다면, 이 PR은 닫혀도 괜찮습니다.