### PR TITLE
[fix] Typo in Generate Field Accessors for Records

### DIFF
--- a/content/JavaScript-Interop/11-Generate-Converters-Helpers/01-@deriving(accessors).md
+++ b/content/JavaScript-Interop/11-Generate-Converters-Helpers/01-@deriving(accessors).md
@@ -6,7 +6,7 @@ sourceUrl: 'https://rescript-lang.org/docs/manual/latest/inlining-constants'
 canonical: 'https://rescript-lang.org/docs/manual/latest/inlining-constants'
 ---
 
-@deriving(acccessors)는 배리언트나 레코드에 사용할 수 있는 어노테이션입니다.
+@deriving(accessors)는 배리언트나 레코드에 사용할 수 있는 어노테이션입니다.
 
 이 어노테이션이 사용되면 접근자 코드가 자동으로 생성됩니다.
 


### PR DESCRIPTION
안녕하세요.
**인터롭 코드 자동 생성하기**의 **@deriving(accessor)** [페이지](https://green-labs.github.io/rescript-in-korean/JavaScript-Interop/11-Generate-Converters-Helpers/01-@deriving(accessors))에서 오타가 발견되어 PR을 올립니다.

## 내용
- `acccessors`을 `accessors`로 수정

## 참조
- [번역본](https://green-labs.github.io/rescript-in-korean/JavaScript-Interop/11-Generate-Converters-Helpers/01-@deriving(accessors))
- [원본](https://rescript-lang.org/docs/manual/latest/generate-converters-accessors#generate-field-accessors-for-records)

감사합니다. 🙏
