### PR TITLE
[fix] Typo in Pipe

### DIFF
--- a/content/Language-Features/14-Pipe.mdx
+++ b/content/Language-Features/14-Pipe.mdx
@@ -37,7 +37,7 @@ a(one, two, three)
 one->a(two, three)
 ```
 
-또한 파이프는 이름이 있는 인자(labeld arguments)에서도 동작합니다.
+또한 파이프는 이름이 있는 인자(labeled arguments)에서도 동작합니다.
 
 자바와 같은 객체 지향 프로그래밍 언어에서는 `myStudent.getName`과 같이 접근할 수 있습니다. 이로써 얻어지는 좋은 가독성은 객체 지향 프로그래밍의 장점입니다. 파이프를 사용하면 리스크립트에서도 `getName(myStudent)`를 `myStudent->getName`처럼 변경해 가독성을 높일 수 있습니다.
 


### PR DESCRIPTION
안녕하세요.
**파이프** [페이지](https://green-labs.github.io/rescript-in-korean/Language-Features/14-Pipe)에서 잘못된 단어를 교정하여 PR을 올립니다.

## 내용
- `labeld` -> `labeled`로 변경

## 참조
- [번역본](https://green-labs.github.io/rescript-in-korean/Language-Features/14-Pipe)
- [원본](https://rescript-lang.org/docs/manual/latest/pipe)

감사합니다. 🙏
