### PR TITLE
[Fix] Typo in Unboxed

### DIFF
--- a/content/Language-Features/24-Unboxed.mdx
+++ b/content/Language-Features/24-Unboxed.mdx
@@ -136,7 +136,7 @@ let playerLocalCoordinates = Local({x: 20.5, y: 30.5})
 
 /* 이제 이렇게 호출하면 오류가 발생합니다! */
 /* renderDot(playerLocalCoordinates) */
-/* 대산 이렇게 사용하도록 강제합니다. */
+/* 대신 이렇게 사용하도록 강제합니다. */
 renderDot(playerLocalCoordinates->toWorldCoordinates)
 ```
 


### PR DESCRIPTION
안녕하세요.
**Unboxed** [페이지](https://green-labs.github.io/rescript-in-korean/Language-Features/24-Unboxed)에서 잘못된 오탈자를 교정하여 PR을 올립니다.

## 내용
- 오탈자 교정

## 참조
- [번역본](https://green-labs.github.io/rescript-in-korean/Language-Features/24-Unboxed)
- [원본](https://rescript-lang.org/docs/manual/latest/unboxed)

감사합니다. 🙏
